### PR TITLE
The default local environment may not have postgres setup as a user.

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -37,8 +37,5 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :dev_wizard, DevWizard.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "postgres",
-  password: "postgres",
   database: "dev_wizard_dev",
-  hostname: "localhost",
   pool_size: 10


### PR DESCRIPTION
This suggested fix came from https://github.com/phoenixframework/phoenix/issues/1345

We could also just add a step to the setup in the readme to create the
postgres user.
