### PR TITLE
Specify Elixir 1.2.1 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: elixir
+elixir:
+  - 1.2.1
 deploy:
   provider: heroku
   app: dev-wizard-rc


### PR DESCRIPTION
Tests are failing since we do not explicitly specify our required Elixir version. This PR specifies version 1.2.1 in the travis config file to ensure that the tests run properly.
