### PR TITLE
Display multiple assignees on the needs review and qa list pages

### DIFF
--- a/lib/dev_wizard/github_gateway/issue.ex
+++ b/lib/dev_wizard/github_gateway/issue.ex
@@ -5,6 +5,7 @@ defmodule DevWizard.GithubGateway.Issue do
 
   defstruct(
     assignee:       nil,
+    assignees:      nil,
     body:           nil,
     closed_at:      nil,
     comments:       nil,

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -44,6 +44,7 @@ defmodule DevWizard.PageController do
     issues =
       gateway
       |> GithubGateway.needs_code_review
+      |> IssueWorkflow.determine_assignees
       |> IssueWorkflow.determine_milestone(storyboard)
 
     conn
@@ -66,6 +67,7 @@ defmodule DevWizard.PageController do
     issues =
       gateway
       |> GithubGateway.needs_qa
+      |> IssueWorkflow.determine_assignees
       |> IssueWorkflow.determine_milestone(storyboard)
 
     conn

--- a/web/templates/page/issue_list.html.eex
+++ b/web/templates/page/issue_list.html.eex
@@ -47,12 +47,13 @@
                           </a>
                         </td>
                         <td>
-                            <%= if pr.assignee do %>
-                              <a class="ui teal label">
-                                <img class="ui right spaced avatar image" src="<%= pr.assignee.avatar_url %>">
-                                <%= pr.assignee.login %>
-                              </a>
+                          <ul>
+                            <%= for assignee <- pr.assignees do %>
+                              <li>
+                                <%= assignee %>
+                              </li>
                             <% end %>
+                          </ul>
                         </td>
                         <td>
                           Updated: <%= days_since(pr.updated_at) %>


### PR DESCRIPTION
We already had logic to pull the issue assignees elsewhere, so we can utilize it to display our version of an issue's assignment since we allow/support multiple assignees.
