### PR TITLE
Color code reviewer bubbles on the needs_code_review list page

### DIFF
--- a/web/templates/page/issue_list.html.eex
+++ b/web/templates/page/issue_list.html.eex
@@ -51,7 +51,7 @@
                             <%= if @phase == :needs_code_review do %>
                               <%= for review <- reviews(pr) do %>
                                 <div class="item" >
-                                  <div class="ui purple label">
+                                  <div class="ui <%= review_to_color(review) %> label">
                                     <%= review.user.login %> -
                                     <%= review.state %>
                                   </div>

--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -25,4 +25,12 @@ defmodule DevWizard.PageView do
   def reviews(issue) do
     Issue.merged_reviews(issue)
   end
+
+  def review_to_color(review) do
+    case review.state do
+      :approved -> "green"
+      :pending  -> "purple"
+      _         -> "red"
+    end
+  end
 end


### PR DESCRIPTION
### What am I?

Since we have review information with each reviewer already figured out, we can color code them on the view to make them easier to scan. 

For example: accepted = green, pending = purple, changes requested = red

### To test

Load the needs code review page and ensure that the color coding described above is observed for all different states of review.

