### PR TITLE
Update tentacat and use its ReviewRequests API

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,3 +35,6 @@ import_config "#{Mix.env}.exs"
 config :phoenix, :generators,
   migration: true,
   binary_id: false
+
+# Custom header for Github Reviews API
+config :tentacat, :extra_headers, [{"Accept", "application/vnd.github.black-cat-preview+json"}]

--- a/lib/dev_wizard/github_gateway/client.ex
+++ b/lib/dev_wizard/github_gateway/client.ex
@@ -38,6 +38,6 @@ defmodule DevWizard.GithubGateway.Client do
   end
 
   def requested_reviewers(client, org, repo, issue)  do
-    Tentacat.Pulls.RequestedReviewers.list(org, repo, issue, client.tentacat)
+    Tentacat.Pulls.ReviewRequests.list(org, repo, issue, client.tentacat)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule DevWizard.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:cowboy, "~> 1.0"},
      {:oauth2, "~> 0.5"},
-     {:tentacat, github: "seejee/tentacat", branch: "cg/requested_reviewers"},
+     {:tentacat, "~> 0.6.0"},
      {:exactor, "~> 2.2.0"},
      {:timex, "~> 2.1.0"},
      {:exconstructor, "~> 1.0.0"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
   "connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
-  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], []},
   "ecto": {:hex, :ecto, "1.1.2", "b18fc577b21dd11b8bcaef6ff06c16793583cd309d359eb22465c180e69bd5ba", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.5.0", [hex: :mariaex, optional: true]}, {:poison, "~> 1.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.10.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}]},
@@ -31,6 +31,6 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "tentacat": {:git, "https://github.com/seejee/tentacat.git", "d1e0b7291de171535920e0f445e6062e7018d752", [branch: "cg/requested_reviewers"]},
+  "tentacat": {:hex, :tentacat, "0.6.2", "e5e5ad95d577dd441e4dcfcab259c9d92b0049f0481a4be6453769d61a956a3b", [:mix], [{:exjsx, "~> 3.2", [hex: :exjsx, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}]},
   "timex": {:hex, :timex, "2.1.4", "17100f0d47473fe05423084039b8f3de9d63617b66d8db676e24a4221216db61", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "tzdata": {:hex, :tzdata, "0.5.7", "10a4176023c2b294f1bbb98594a646ef25d658ca507b2da20a5952072d6080c4", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}


### PR DESCRIPTION
We were on a fork of tentacat because it didn't support Github's API for review requests yet, but it
has since been updated.  This switches us to the latest tentacat off the main repo, and updates our
app to use the correct API call.  The custom header in the config file is necessary because the
reviews stuff is still in a pre-release state.

The creation of this PR was sparked by the QA list failing to load.  I was able to reproduce that issue locally, and once I made these changes the QA list successfully loaded, but I'm not sure why this fixed that.